### PR TITLE
Added wake lock feature

### DIFF
--- a/android/src/main/java/com/wix/reactnativenotifications/fcm/FcmMessageHandlerService.java
+++ b/android/src/main/java/com/wix/reactnativenotifications/fcm/FcmMessageHandlerService.java
@@ -1,6 +1,9 @@
 package com.wix.reactnativenotifications.fcm;
 
 import android.util.Log;
+import android.os.PowerManager;
+import android.os.PowerManager.WakeLock;
+import android.content.Context;
 
 import com.google.firebase.messaging.FirebaseMessagingService;
 import com.google.firebase.messaging.RemoteMessage;
@@ -16,5 +19,15 @@ public class FcmMessageHandlerService extends FirebaseMessagingService {
         Log.d(LOGTAG, "New message from firebase");
         final NotificationProps notificationProps = NotificationProps.fromRemoteMessage(this, message);
         new RemoteNotification(this, notificationProps).onReceived();
+
+        PowerManager pm = (PowerManager) getSystemService(Context.POWER_SERVICE);
+        boolean isScreenOn = pm.isScreenOn();
+        Log.e("screen on.................................", ""+isScreenOn);
+        if(isScreenOn==false){
+            WakeLock wl = pm.newWakeLock(PowerManager.FULL_WAKE_LOCK |PowerManager.ACQUIRE_CAUSES_WAKEUP |PowerManager.ON_AFTER_RELEASE,"MyLock");
+            wl.acquire(10000);
+            WakeLock wl_cpu = pm.newWakeLock(PowerManager.PARTIAL_WAKE_LOCK,"MyCpuLock");
+            wl_cpu.acquire(10000);
+        }
     }
 }


### PR DESCRIPTION
Android devices have background limitations. When the app is killed and the device screen is asleep, the OS will not allow the app to process any notifications received. The app will only be allowed to process it when the screens comes on. The added feature in this PR will wake the device screen up when a notification is received to allow the app to process it. This will solve the issue for the app not showing notifications when the app is killed and the device is asleep. 